### PR TITLE
New option (MemberPress integration): limit Turnstile to specific registration forms

### DIFF
--- a/inc/admin/admin-options.php
+++ b/inc/admin/admin-options.php
@@ -80,7 +80,7 @@ function cfturnstile_settings_page() {
 
 		<h1 style="font-weight: bold;"><?php echo esc_html__('Simple Cloudflare Turnstile', 'simple-cloudflare-turnstile'); ?></h1>
 
-		<p style="margin-bottom: 0;"><?php echo esc_html__('Easily add the new "Cloudflare Turnstile" to your WordPress forms to help prevent spam.', 'simple-cloudflare-turnstile'); ?> <a href="https://www.cloudflare.com/en-gb/products/turnstile/" target="_blank"><?php echo esc_html__('Learn more.', 'simple-cloudflare-turnstile'); ?></a>
+		<p style="margin-bottom: 0;"><?php echo esc_html__('Easily add the free CAPTCHA service called "Cloudflare Turnstile" to your WordPress forms to help prevent spam.', 'simple-cloudflare-turnstile'); ?> <a href="https://www.cloudflare.com/en-gb/products/turnstile/" target="_blank"><?php echo esc_html__('Learn more.', 'simple-cloudflare-turnstile'); ?></a>
 
 		<div class="sct-admin-promo-top">
 
@@ -351,7 +351,7 @@ function cfturnstile_settings_page() {
 						<th scope="row"><?php echo esc_html__('IP Addresses', 'simple-cloudflare-turnstile'); ?></th>
 						<td>
 							<textarea style="width: 240px;" name="cfturnstile_whitelist_ips"><?php echo sanitize_textarea_field(get_option('cfturnstile_whitelist_ips')); ?></textarea>
-							<br /><i style="font-size: 10px;"><?php echo esc_html__('One per line. All visitors with listed IP addresses will not see the Turnstile challenge. Warning: If an attacker knows one of the whitelisted IP addresses, they might be able to spoof that address to bypass Turnstile.', 'simple-cloudflare-turnstile'); ?></i>
+							<br /><i style="font-size: 10px;"><?php echo esc_html__('One per line. Wildcards are not supported. All visitors with listed IP addresses will not see the Turnstile challenge. Warning: If an attacker knows one of the whitelisted IP addresses, they might be able to spoof that address to bypass Turnstile.', 'simple-cloudflare-turnstile'); ?></i>
 						</td>
 					</tr>
 
@@ -759,6 +759,7 @@ function cfturnstile_settings_page() {
 					</table>
 
 					<?php echo esc_html__('When enabled, Turnstile will be added before/after the submit button, on ALL your forms created with WPForms.', 'simple-cloudflare-turnstile'); ?>
+					<?php echo esc_html__('Remember that WPForms has an option to configure Turnstile on its own Settings page > CAPTCHA tab. You should only enable it in one place: either here –OR– in those Settings.', 'simple-cloudflare-turnstile'); ?>
 
 					<table class="form-table" style="margin-bottom: -15px;">
 

--- a/inc/admin/admin-options.php
+++ b/inc/admin/admin-options.php
@@ -1209,7 +1209,13 @@ function cfturnstile_settings_page() {
 			?>
 
 			<?php // MemberPress
-			if (cft_is_plugin_active('memberpress/memberpress.php')) { ?>
+			if (cft_is_plugin_active('memberpress/memberpress.php')) { 
+
+				if(get_option('cfturnstile_mepr_product_ids')) {
+				  $LimitedToProductIDs = get_option('cfturnstile_mepr_product_ids');
+				  $ProductsNeedingCaptcha = explode("\n", str_replace("\r", "", $LimitedToProductIDs));
+				}
+				?>
 				<button type="button" class="sct-accordion"><?php echo esc_html__('MemberPress', 'simple-cloudflare-turnstile'); ?></button>
 				<div class="sct-panel">
 
@@ -1236,9 +1242,24 @@ function cfturnstile_settings_page() {
 
 						<tr valign="top">
 							<th scope="row">
-								<?php echo esc_html__('Register/Checkout Form', 'simple-cloudflare-turnstile'); ?>
+								<?php echo esc_html__('Registration/Checkout Forms', 'simple-cloudflare-turnstile'); 
+								if(get_option('cfturnstile_mepr_product_ids')) {
+									?>
+								<br><span style="font-weight:400;font-size:12px;"><span style="color:#d1242f;">currently limited to:</span>
+								<br><?php echo implode(', ' , $ProductsNeedingCaptcha); ?></span>
+								<?php
+								}
+								?>
 							</th>
 							<td><input type='checkbox' name='cfturnstile_mepr_register' id='cfturnstile_mepr_register' <?php if (get_option('cfturnstile_mepr_register')) { ?>checked<?php } ?>></td>
+						</tr>
+						<tr valign="top">
+							<th scope="row">
+								<?php echo esc_html__('—but ONLY for these Membership IDs:', 'simple-cloudflare-turnstile'); ?></th>
+							<td>
+								<textarea style="width: 240px;" name="cfturnstile_mepr_product_ids"><?php echo sanitize_textarea_field(get_option('cfturnstile_mepr_product_ids')); ?></textarea>
+								<br /><i style="font-size: 10px;"><?php echo esc_html__('One per line. For Membership products that are not on this list, no Turnstile challenge will be loaded or enforced.', 'simple-cloudflare-turnstile'); ?></i>
+							</td>
 						</tr>
 
 					</table>

--- a/inc/admin/register-settings.php
+++ b/inc/admin/register-settings.php
@@ -129,6 +129,7 @@ function cfturnstile_settings_list($all = false) {
         'memberpress/memberpress.php' => array(
             'cfturnstile_mepr_login',
             'cfturnstile_mepr_register',
+            'cfturnstile_mepr_product_ids',
         ),
         'wp-user-frontend/wpuf.php' => array(
             'cfturnstile_wpuf_register',

--- a/inc/integrations/membership/memberpress.php
+++ b/inc/integrations/membership/memberpress.php
@@ -3,15 +3,37 @@ if ( ! defined( 'ABSPATH' ) ) {
   exit;
 }
 
+// Get turnstile field: MemberPress Constraints
+if(get_option('cfturnstile_mepr_product_ids')) {
+  $LimitedToProductIDs = get_option('cfturnstile_mepr_product_ids');
+  $ProductsNeedingCaptcha = explode("\n", str_replace("\r", "", $LimitedToProductIDs));
+} else {
+  $ProductsNeedingCaptcha = array('0');
+}
+
 // Get turnstile field: MemberPress
 if(get_option('cfturnstile_login')) { add_action('mepr-login-form-before-submit','cfturnstile_field_mepr'); }
 if(get_option('cfturnstile_mepr_register')) { add_action('mepr-checkout-before-submit','cfturnstile_field_mepr'); }
-function cfturnstile_field_mepr() { cfturnstile_field_show('.mepr-submit', 'turnstileMEPRCallback', 'memberpress', '-' . wp_rand()); }
+function cfturnstile_field_mepr($membership_ID) { 
+  global $ProductsNeedingCaptcha;
+
+  // only show Turnstile for those specific product ids
+  if( in_array( $membership_ID, $ProductsNeedingCaptcha )) {
+    cfturnstile_field_show(
+      '.mepr-submit', 
+      'turnstileMEPRCallback', 
+      'memberpress', 
+      '-' . wp_rand()
+    ); 
+  }
+}
 
 // MemberPress Check
 if(get_option('cfturnstile_mepr_register')) { add_filter( 'mepr-validate-signup', 'cfturnstile_mepr_check', 20, 1 ); }
 
 function cfturnstile_mepr_check( $errors ) {
+
+  global $ProductsNeedingCaptcha;
 
   // Start session
   if (!session_id()) { session_start(); }
@@ -26,7 +48,12 @@ function cfturnstile_mepr_check( $errors ) {
     return $errors;
   }
 
-  // Check
+  // Suppress Turnstile on all non-specified product ids
+  if( !in_array( $_POST['mepr_product_id'], $ProductsNeedingCaptcha )) {
+    return $errors;
+  }
+  
+  // Check Turnstile outcome
   if ( 'POST' === $_SERVER['REQUEST_METHOD'] && isset( $_POST['cf-turnstile-response'] ) ) {
     $check = cfturnstile_check();
     $success = $check['success'];

--- a/readme.txt
+++ b/readme.txt
@@ -70,7 +70,7 @@ The plugin includes several other features and options:
 * Appearance Mode: Choose if Turnstile is always displayed, or only when an interaction is required.
 * Disable Submit Button: Disable the submit button on forms until the Turnstile challenge is completed.
 * Custom Error Message: Set your own custom error message for failed submissions.
-* Whitelist: Prevent Turnstile from showing for logged in users, or certain IP addresses.
+* Whitelist: Prevent Turnstile from showing for logged in users, or certain IP addresses (wildcards are not supported).
 
 ## Getting Started ##
 
@@ -180,6 +180,14 @@ If you are still having issues, please post a <a href="https://wordpress.org/sup
 = How can I report security bugs? =
 
 You can report security bugs through the Patchstack Vulnerability Disclosure Program. The Patchstack team help validate, triage and handle any security vulnerabilities. [Report a security vulnerability.](https://patchstack.com/database/vdp/simple-cloudflare-turnstile)
+
+== Code Fork: == 
+=== auutstudio/simple-cloudflare-turnstile-sometimes ===
+
+= Version 1.25.0.001 -  May 2024 =
+- New: Added an option to only show Turnstile on specific MemberPress registration forms, based on a declared list of Membership Product IDs.
+- Tweak: Clarify that the Whitelist IP option does not support wildcards.
+- Tweak: Clarify that WPForms has a redundant place in its own settings to configure Turnstile.
 
 == Changelog ===
 


### PR DESCRIPTION
More granular control of Turnstile is necessary for advanced users of MemberPress. This is because one feature of MemberPress Pro allows for signups on a membership to be restricted to those visitors who arrive on (very wide) ranges of IP addresses [by using wildcards].  The Whitelist IP option in Simple Cloudflare Turnstile doesn't support wildcards (although this fact isn't documented anywhere), so the number of individual IP addresses to list manually could quickly reach tens of thousands.

What's more:
1) the ability to configure MemberPress in this manner enables a use-case that some organizational customers rely upon:  They might direct their entire staff to access the WordPress site from an alternate proxy URL (or multiple proxy URLs) such as:
    ourmembershipsite-com.proxy1.theircompany.org/register/gold-plan/
    ourmembershipsite-com.proxy2.theircompany.org/register/gold-plan/
2) Anyone's Cloudflare account needs all domains that will utilize the API to be declared in advance, of course. Even if all proxy URLs from all customers can be gleaned in advance, those URLs could be changed at their whim, without notice. 
3) If ever that domain is one not prelisted on the Cloudflare account, then those customers will receive an 'Invalid Domain' error from Turnstile -- and have no possible recourse to move past the registration form.

As a result, it's important to have the ability to limit Turnstile to **only a subset of** MemberPress forms, much like can be accomplished for WPForms by disabling specific IDs. 

This pull request adds a new setting for storing a list of MemberPress product IDs, separated by newlines, which become an array to compare at runtime to determine whether to load a Turnstile challenge or not.