### PR TITLE
Add Checkout block and Store API support

### DIFF
--- a/inc/admin/admin-options.php
+++ b/inc/admin/admin-options.php
@@ -523,23 +523,6 @@ function cfturnstile_settings_page() {
 							<td><input type="checkbox" name="cfturnstile_woo_reset" <?php if (get_option('cfturnstile_woo_reset')) { ?>checked<?php } ?>></td>
 						</tr>
 
-						<?php
-						$checkout_page_id = get_option('woocommerce_checkout_page_id');
-						$checkout_page_content = get_post_field('post_content', $checkout_page_id);
-						if (strpos($checkout_page_content, 'wp:woocommerce/checkout') !== false) {
-						?>
-
-						<tr valign="top">
-							<th scope="row">
-								<?php echo esc_html__('WooCommerce Checkout', 'simple-cloudflare-turnstile'); ?>
-							</th>
-							<td>
-							<i style="font-size: 12px; color: red;"><?php echo esc_html__("Currently not compatible with the new 'block-based' checkout.", 'simple-cloudflare-turnstile'); ?></i>
-							</td>
-						</tr>
-
-						<?php } else { ?>
-
 						<tr valign="top">
 							<th scope="row">
 								<?php echo esc_html__('WooCommerce Checkout', 'simple-cloudflare-turnstile'); ?>
@@ -573,8 +556,6 @@ function cfturnstile_settings_page() {
 								</select>
 							</td>
 						</tr>
-
-						<?php } ?>
 
 						<tr valign="top" style="border-bottom: 1px solid #f3f3f3;">
 							<th scope="row">

--- a/js/integrations/woocommerce.js
+++ b/js/integrations/woocommerce.js
@@ -18,3 +18,23 @@ jQuery('.showlogin').on('click', function() {
     turnstile.remove('.sct-woocommerce-login');
     turnstile.render('.sct-woocommerce-login');
 });
+
+/* Woo Checkout Block */
+if ( wp && wp.data ) {
+    var unsubscribe = wp.data.subscribe(function() {
+        const turnstileItem = document.getElementById('cf-turnstile-woo-checkout');
+        if(turnstile) {
+            turnstile.render(turnstileItem, {
+                sitekey: turnstileItem.dataset.sitekey,
+                callback: function(data) {
+                    wp.data.dispatch('wc/store/checkout').__internalSetExtensionData('simple-cloudflare-turnstile', {
+                        token: data
+                    })
+                }
+            });
+
+            turnstile.onEx
+            unsubscribe();
+        }
+    }, 'wc/store/cart');
+}


### PR DESCRIPTION
Similar to https://github.com/ElliotSowersby/recaptcha-woo/pull/6 this adds Checkout block and Store API support

I removed the checks in the plugin that disables this for Checkout block, added support to Store API and rendered the item in Checkout block. All positions work fine.

As with the other PR, I didn't see a need to reset the token each time, it seems Cloudflare would refresh the token if it's not working.

Happy to maintain this further if any bugs arise, do feel to ping me.