### PR TITLE
Add turnstile and turnstileItem existence check

### DIFF
--- a/js/integrations/woocommerce.js
+++ b/js/integrations/woocommerce.js
@@ -20,10 +20,10 @@ jQuery('.showlogin').on('click', function() {
 });
 
 /* Woo Checkout Block */
-if ( wp && wp.data ) {
+if ( wp && wp.data && turnstile ) {
     var unsubscribe = wp.data.subscribe(function() {
         const turnstileItem = document.getElementById('cf-turnstile-woo-checkout');
-        if(turnstile) {
+        if(turnstileItem) {
             turnstile.render(turnstileItem, {
                 sitekey: turnstileItem.dataset.sitekey,
                 callback: function(data) {


### PR DESCRIPTION
Add turnstile and turnstileItem existence check to prevent undefined errors. Please see https://wordpress.org/support/topic/woocommerce-cannot-read-properties-of-null-reading-dataset/
