### PR TITLE
fix: change from gform_pre_submission to gform_validation

### DIFF
--- a/inc/integrations/forms/gravity-forms.php
+++ b/inc/integrations/forms/gravity-forms.php
@@ -42,20 +42,52 @@ if(get_option('cfturnstile_gravity')) {
   }
 
   // Gravity Forms Check
-	add_action('gform_pre_submission', 'cfturnstile_gravity_check', 10, 1);
-	function cfturnstile_gravity_check($form) {
-    if(!cfturnstile_whitelisted() && !cfturnstile_form_disable($form['id'], 'cfturnstile_gravity_disable')) {
-  		if ( 'POST' === $_SERVER['REQUEST_METHOD'] && isset( $_POST['cf-turnstile-response'] ) ) {
-  			$check = cfturnstile_check();
-  			$success = $check['success'];
-  			if($success != true) {
-          wp_die( '<p><strong>' . esc_html__( 'ERROR:', 'simple-cloudflare-turnstile' ) . '</strong> ' . cfturnstile_failed_message() . '</p>', 'simple-cloudflare-turnstile', array( 'response'  => 403, 'back_link' => 1, ) );
-  			}
-  		} else {
-        wp_die( '<p><strong>' . esc_html__( 'ERROR:', 'simple-cloudflare-turnstile' ) . '</strong> ' . cfturnstile_failed_message() . '</p>', 'simple-cloudflare-turnstile', array( 'response'  => 403, 'back_link' => 1, ) );
-  		}
+  add_action('gform_validation', 'cfturnstile_gravity_check', 10, 4);
+
+  function cfturnstile_gravity_check($validation_result)
+  {
+    $form = $validation_result['form'];
+    // if whitelisted or form is disabled, return
+    if (cfturnstile_whitelisted() || cfturnstile_form_disable($form['id'], 'cfturnstile_gravity_disable')) {
+      return $validation_result;
     }
-    return $form;
-	}
+    
+    // if not a POST request or no cf-turnstile-response, return
+    if ('POST' !== $_SERVER['REQUEST_METHOD'] || !isset($_POST['cf-turnstile-response'])) {
+      $_SESSION['cf-turnstile-response'] = cfturnstile_failed_message();
+      $validation_result['is_valid'] = false;
+      add_filter('gform_validation_message_' . $form['id'], 'cfturnstile_gravity_validation_message', 10, 2);
+      return $validation_result;
+    }
+
+    $check = cfturnstile_check();
+    $success = $check['success'];
+    // if check fails, return error
+    if ($success != true) {
+      $_SESSION['cf-turnstile-response'] = cfturnstile_failed_message();
+      $validation_result['is_valid'] = false;
+      add_filter('gform_validation_message_' . $form['id'], 'cfturnstile_gravity_validation_message', 10, 2);
+
+      return $validation_result;
+    }
+  
+    return $validation_result;
+  }
+
+  function cfturnstile_gravity_validation_message($message, $form)
+  {
+    if (isset($_SESSION['cf-turnstile-response'])) {
+      $error = $_SESSION['cf-turnstile-response'];
+      unset($_SESSION['cf-turnstile-response']);
+
+      $message = '<div class="gform_validation_errors" id="gform_' . $form['id'] . '_validation_container">
+      <h2 class="gform_submission_error hide_summary"><span class="gform-icon gform-icon--close"></span>
+      ' . $error . '
+      </h2>
+      </div>';
+    }
+
+    return $message;
+  }
 
 }


### PR DESCRIPTION
When running validation on GravityForms, we should be using `gform_validation`, instead of `gform_pre_submission`.

Currently if turnstile fails validation, it will return a 403 which GravityForms won't see. The form simply doesn't show an error, or re-render the form.

This change moves the verification to the validation hook, and uses the native GravityForms error messaging to return the error.