### PR TITLE
Fix duplicate turnstile with CheckoutWC

### DIFF
--- a/inc/integrations/ecommerce/woocommerce.php
+++ b/inc/integrations/ecommerce/woocommerce.php
@@ -63,7 +63,10 @@ function cfturnstile_render_pre_block($block_content) {
 // Woo Checkout Check
 if(get_option('cfturnstile_woo_checkout')) {
 	// WooCommerce Checkout
-	if(empty(get_option('cfturnstile_woo_checkout_pos')) || get_option('cfturnstile_woo_checkout_pos') == "beforepay") {
+	if(function_exists( 'cfw_templates_disabled' ) && cfw_templates_disabled()) {
+		// CheckoutWC - permissioned init hook runs when CheckoutWC is enabled
+		add_action('cfw_checkout_before_payment_method_tab_nav', 'cfturnstile_field_checkout', 10);
+	} elseif(empty(get_option('cfturnstile_woo_checkout_pos')) || get_option('cfturnstile_woo_checkout_pos') == "beforepay") {
 		add_action('woocommerce_review_order_before_payment', 'cfturnstile_field_checkout', 10);
 		add_filter('render_block_woocommerce/checkout-payment-block', 'cfturnstile_render_pre_block', 999, 1); // Before Payment block.
 	} elseif(get_option('cfturnstile_woo_checkout_pos') == "afterpay") {
@@ -80,8 +83,7 @@ if(get_option('cfturnstile_woo_checkout')) {
 		add_filter('render_block_woocommerce/checkout-actions-block', 'cfturnstile_render_pre_block', 999, 1); // Before Actions block, not sure if this option is still supported.
 
 	}
-	// CheckoutWC
-	add_action('cfw_checkout_payment_method_tab', 'cfturnstile_field_checkout', 10);
+
 	// Check Turnstile
 	add_action('woocommerce_checkout_process', 'cfturnstile_woo_checkout_check');
 	function cfturnstile_woo_checkout_check() {


### PR DESCRIPTION
Hi there, 

We have a customer reporting a duplicated turnstile button. This seems to be because the CheckoutWC version is added regardless of the other positional settings, resulting in it being placed twice.

I've also adjusted the hook that it outputs on to move it just the place order button row. 

This seems more semantically correct than after the payment methods.

Let me know your thoughts!