### PR TITLE
Update woocommerce.js

### DIFF
--- a/js/integrations/woocommerce.js
+++ b/js/integrations/woocommerce.js
@@ -85,6 +85,7 @@ document.addEventListener('DOMContentLoaded', function() {
         
         function setTurnstileExtensionData(token) {
             var dispatch = wp.data.dispatch('wc/store/checkout');
+            if (!dispatch) return;
             if (typeof dispatch.setExtensionData === 'function') {
                 dispatch.setExtensionData('simple-cloudflare-turnstile', { token: token });
             } else if (typeof dispatch.__internalSetExtensionData === 'function') {


### PR DESCRIPTION
Fixed error:

Uncaught TypeError: can't access property "setExtensionData", dispatch is null
    setTurnstileExtensionData simple-cloudflare-turnstile/js/integrations/woocommerce.js?ver=1.3:88

----------

Summary of what was wrong and what was changed:
Cause: wp.data.dispatch('wc/store/checkout') can be null when: The page uses classic checkout (no Blocks), or
The WooCommerce Blocks checkout store isn’t registered yet, or WooCommerce/Blocks versions differ.
The code was calling dispatch.setExtensionData (and the fallback) without checking dispatch, which triggers “can’t access property ‘setExtensionData’, dispatch is null”.