### PR TITLE
fix(whitelist): add excluded pages and disable hook

### DIFF
--- a/inc/admin/admin-options.php
+++ b/inc/admin/admin-options.php
@@ -591,6 +591,14 @@ function cfturnstile_settings_page() {
 						</td>
 					</tr>
 
+					<tr valign="top">
+						<th scope="row"><?php echo esc_html__('Excluded Page URLs', 'simple-cloudflare-turnstile'); ?></th>
+						<td>
+							<textarea style="width: 240px;" name="cfturnstile_whitelist_pages"><?php echo sanitize_textarea_field(get_option('cfturnstile_whitelist_pages')); ?></textarea>
+							<br /><i style="font-size: 10px;"><?php echo esc_html__('Enter keyword or paths (one per line) to disable Turnstile on specific pages. Examples: /my-account/ or popup. If the URL contains this text, Turnstile will be disabled completely.', 'simple-cloudflare-turnstile'); ?></i>
+						</td>
+					</tr>
+
 				</table>
 
 			</div>

--- a/inc/admin/register-settings.php
+++ b/inc/admin/register-settings.php
@@ -67,6 +67,7 @@ function cfturnstile_settings_list($all = false) {
         'cfturnstile_whitelist_users',
         'cfturnstile_whitelist_ips',
         'cfturnstile_whitelist_agents',
+        'cfturnstile_whitelist_pages',
     );
 
     $integrations = array(

--- a/inc/whitelist.php
+++ b/inc/whitelist.php
@@ -35,6 +35,23 @@ function cfturnstile_whitelisted() {
             }
         }
     }
+    // Excluded Page URLs
+    if (get_option('cfturnstile_whitelist_pages')) {
+        $whitelist_pages = explode("\n", str_replace("\r", "", get_option('cfturnstile_whitelist_pages')));
+        
+        $current_url = '';
+        if ( isset( $_SERVER['REQUEST_URI'] ) ) {
+            $current_url = sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) );
+        }
+
+        foreach ( $whitelist_pages as $whitelist_page ) {
+            $whitelist_page = sanitize_text_field( trim( $whitelist_page ) );
+            if ( $current_url && $whitelist_page && strpos( $current_url, $whitelist_page ) !== false ) {
+                $whitelisted = true;
+                break;
+            }
+        }
+    }
     // If the User Agent is within the list of User Agents in get_option('cfturnstile_whitelist_agents')
     if (get_option( 'cfturnstile_whitelist_agents' )) {
         $whitelist        = get_option( 'cfturnstile_whitelist_agents' );

--- a/simple-cloudflare-turnstile.php
+++ b/simple-cloudflare-turnstile.php
@@ -85,6 +85,16 @@ if (!empty(get_option('cfturnstile_key')) && !empty(get_option('cfturnstile_secr
 	add_action("cfturnstile_enqueue_scripts", "cfturnstile_script_enqueue");
 	add_action("login_enqueue_scripts", "cfturnstile_script_enqueue");
 	function cfturnstile_script_enqueue() {
+		// Hook to completely disable scripts
+		if ( apply_filters('simple_cloudflare_turnstile_disable', false) ) {
+			return;
+		}
+		
+		// If page/user is whitelisted, do not load scripts
+		if ( function_exists('cfturnstile_whitelisted') && cfturnstile_whitelisted() ) {
+			return;
+		}
+
 		// Get current theme
 		$current_theme = wp_get_theme();
 		// Check defer scripts option


### PR DESCRIPTION
## Summary

Allows users to exclude specific pages from Turnstile using a new admin setting and adds a developer hook to disable the plugin programmatically. This resolves issues where Turnstile conflicts with specific popup or dynamic login integrations.

Fixes #65

## Problem

Some third-party plugins (like YITH Easy Login & Register Popup) render forms in ways that conflict with Turnstile's automatic script enqueuing, causing rendering errors or preventing form submissions on specific pages.

## Solution

Implementation of a two-layered bypass:
1. An admin setting to exclude pages based on URL string matching.
2. A `simple_cloudflare_turnstile_disable` filter hook to allow developers to conditionally disable the plugin firing.

## Changes

### `inc/whitelist.php`

**Before:**
```php
function cfturnstile_whitelisted() {
    // ... (logic for IP and UA)
}
```

**After:**
```php
    // Excluded Page URLs
    if (get_option('cfturnstile_whitelist_pages')) {
        $whitelist_pages = explode("\n", str_replace("\r", "", get_option('cfturnstile_whitelist_pages')));
        // ... (check current URL)
    }
```

**Why:** Centralizes the bypass logic within the existing whitelist architecture, ensuring consistency for both rendering and verification.

### `simple-cloudflare-turnstile.php`

**Before:**
```php
	function cfturnstile_script_enqueue() {
		// Get current theme
```

**After:**
```php
	function cfturnstile_script_enqueue() {
		if ( apply_filters('simple_cloudflare_turnstile_disable', false) ) {
			return;
		}
		if ( function_exists('cfturnstile_whitelisted') && cfturnstile_whitelisted() ) {
			return;
		}
```

**Why:** Prevents the Turnstile API from being enqueued when a bypass condition is met, reducing unnecessary requests and avoiding UI conflicts.

## Testing

**Test 1: Admin Page Exclusion**
**Steps:** 
1. Add `/my-account/` to "Excluded Page URLs" in settings.
2. Visit the page.
Result: Turnstile script is not loaded and widget is hidden.

**Test 2: Filter Hook**
**Steps:** Add `add_filter('simple_cloudflare_turnstile_disable', '__return_true');` to functions.php.
Result: Turnstile is disabled across the entire site.

## Build

[simple-cloudflare-turnstile-fix-65.zip](https://github.com/user-attachments/files/26941619/simple-cloudflare-turnstile-fix-65.zip) available for manual testing

## Screen recording
<img width="1564" height="782" alt="Exclude Pages from CF Turnstile" src="https://github.com/user-attachments/assets/8a2da4ff-cdc9-42bb-bbef-7911b3ea17e8" />
