### PR TITLE
fix(elementor): prevent form submission on turnstile failure

### DIFF
--- a/js/integrations/elementor-forms.js
+++ b/js/integrations/elementor-forms.js
@@ -76,6 +76,12 @@ function cfturnstile_init_elementor_forms() {
           if (typeof turnstileElementorCallback === 'function') {
             turnstileElementorCallback(token);
           }
+        },
+        'error-callback': function() {
+          if (disableSubmit && submitButton) {
+            submitButton.style.pointerEvents = 'none';
+            submitButton.style.opacity = '0.5';
+          }
         }
       });
       
@@ -124,12 +130,41 @@ document.addEventListener('click', function(event) {
         turnstile.render(widget, {
           sitekey: cfturnstileElementorSettings.sitekey,
           callback: 'turnstileCallback',
-          theme: cfturnstileElementorSettings.theme || 'auto'
+          theme: cfturnstileElementorSettings.theme || 'auto',
+          'error-callback': function() {
+            var submitBtn = submittedForm.querySelector('button[type="submit"]');
+            var disableSubmit = cfturnstileElementorSettings.disableSubmit || false;
+            if (disableSubmit && submitBtn) {
+              submitBtn.style.pointerEvents = 'none';
+              submitBtn.style.opacity = '0.5';
+            }
+          }
         });
       }
     }, 2000);
   }
 });
+
+// Intercept form submission to ensure Turnstile is completed
+document.addEventListener('submit', function(event) {
+  var form = event.target;
+  if (form && form.classList && form.classList.contains('elementor-form')) {
+    var settings = window.cfturnstileElementorSettings || {};
+    var mode = settings.mode || 'turnstile';
+    if (mode !== 'turnstile' || !window.turnstile) {
+      return;
+    }
+    
+    var widget = form.querySelector('.cf-turnstile');
+    if (widget) {
+      var responseInput = form.querySelector('[name="cf-turnstile-response"]');
+      if (!responseInput || !responseInput.value) {
+        event.preventDefault();
+        event.stopImmediatePropagation();
+      }
+    }
+  }
+}, true);
 
 // Handle Elementor popup show events (jQuery event - must use jQuery to listen)
 jQuery(document).on('elementor/popup/show', function(event, id, instance) {
@@ -173,6 +208,12 @@ jQuery(document).on('elementor/popup/show', function(event, id, instance) {
           }
           if (typeof turnstileElementorCallback === 'function') {
             turnstileElementorCallback(token);
+          }
+        },
+        'error-callback': function() {
+          if (disableSubmit && submitButton) {
+            submitButton.style.pointerEvents = 'none';
+            submitButton.style.opacity = '0.5';
           }
         },
         theme: cfturnstileElementorSettings.theme || 'auto'


### PR DESCRIPTION
## Summary

Prevents Elementor form submission when Turnstile verification is missing or fails. Intercepts the submit event early using event capture to stop execution.

Fixes #67

## Problem

When Turnstile fails to render or remains unsolved, Elementor Forms can still be submitted via keyboard shortcuts (Enter key) or if the submit button is re-enabled by other scripts. This bypasses the security check and triggers "after submission" steps incorrectly.

## Solution

Implemented a document-level `submit` event listener with capturing enabled. This allows interception of the form submission before it reaches Elementor's standard jQuery handlers. If the Turnstile response is missing, the submission is explicitly cancelled and propagation stopped.

## Changes

### `js/integrations/elementor-forms.js`

**Before:**
```javascript
// No submission interception, relied on visual button disabling
```

**After:**
```javascript
document.addEventListener('submit', function(event) {
  // Check if form is elementor-form and turnstile is enabled
  // ...
  if (widget) {
    var responseInput = form.querySelector('[name="cf-turnstile-response"]');
    if (!responseInput || !responseInput.value) {
      event.preventDefault();
      event.stopImmediatePropagation();
    }
  }
}, true);
```

**Why:** Using capture mode (`true`) ensures our listener runs before almost any other handler on the page, allowing us to safely halt the AJAX submission process if verification hasn't occurred.

## Testing

**Test 1: Keyboard Submission**
Steps: 
1) Open popup with form 
2) Fill input 
3) Press Enter without solving Turnstile

Result: Submission is blocked and nothing happens.

**Test 2: Failed Rendering**
Steps: 
1) Simulate API failure/error 
2) Try to click submit

Result: error-callback re-disables the button visuals if configured.

## Build
[simple-cloudflare-turnstile-fix-67.zip](https://github.com/user-attachments/files/26942837/simple-cloudflare-turnstile-fix-67.zip) available for manual testing.
**Install:** WP Admin → Plugins → Upload